### PR TITLE
fix: Prevent concurrent facter invocations

### DIFF
--- a/manifests/mcollective/facts.pp
+++ b/manifests/mcollective/facts.pp
@@ -40,7 +40,7 @@ inherits puppet::mcollective {
 
   cron { 'mcollective-facts':
     ensure      => $enable,
-    command     => "${facter_cmd} 2>/dev/null > ${yamlfile}.new && ! diff -q ${yamlfile}.new ${yamlfile} >/dev/null 2>&1 && mv ${yamlfile}.new ${yamlfile} >/dev/null 2>&1",
+    command     => "flock -n /tmp/facter.lock ${facter_cmd} 2>/dev/null > ${yamlfile}.new && ! diff -q ${yamlfile}.new ${yamlfile} >/dev/null 2>&1 && mv ${yamlfile}.new ${yamlfile} >/dev/null 2>&1",
     minute      => $minute,
   }
 


### PR DESCRIPTION
Prevent situation when facter is run concurrently for any reason.
This should prevent also situation where facter is stuck on something,
and next invocations eats up resources.